### PR TITLE
Runtime env vars; fix for stateless builds

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,3 +1,4 @@
 https://github.com/heroku/heroku-buildpack-nodejs.git
-https://github.com/mars/create-react-app-inner-buildpack.git#v1.3.0
+https://github.com/mars/create-react-app-inner-buildpack.git#stateless-build
+https://github.com/heroku/heroku-buildpack-mustache.git
 https://github.com/heroku/heroku-buildpack-static.git

--- a/.buildpacks
+++ b/.buildpacks
@@ -1,4 +1,4 @@
 https://github.com/heroku/heroku-buildpack-nodejs.git
-https://github.com/mars/create-react-app-inner-buildpack.git
+https://github.com/mars/create-react-app-inner-buildpack.git#runtime-env-vars
 https://github.com/heroku/heroku-buildpack-mustache.git
 https://github.com/heroku/heroku-buildpack-static.git

--- a/.buildpacks
+++ b/.buildpacks
@@ -1,4 +1,4 @@
 https://github.com/heroku/heroku-buildpack-nodejs.git
-https://github.com/mars/create-react-app-inner-buildpack.git#stateless-build
+https://github.com/mars/create-react-app-inner-buildpack.git
 https://github.com/heroku/heroku-buildpack-mustache.git
 https://github.com/heroku/heroku-buildpack-static.git

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Usually, using master [as directed in the main instructions](#create-the-heroku-
 Architecture 🏙
 ------------
 
-This buildpack composes three buildpacks (specified in [`.buildpacks`](.buildpacks)) to support **no-configuration deployment** on Heroku:
+This buildpack composes several buildpacks (specified in [`.buildpacks`](.buildpacks)) to support **no-configuration deployment** on Heroku:
 
 1. [`heroku/nodejs` buildpack](https://github.com/heroku/heroku-buildpack-nodejs)
   * complete Node.js enviroment to support the webpack build

--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ For variables that may change between releases or environments:
   * URLs to APIs
   * secret tokens
 
+Any environment variable is accessible at runtime, not just `REACT_APP_*`.
+
 Add script element to `index.html` to capture environment variable values:
 
 ```html

--- a/README.md
+++ b/README.md
@@ -108,15 +108,23 @@ Create a `static.json` file to configure the web server for clean [`browserHisto
 
 ### Environment variables
 
-[`REACT_APP_*`](https://github.com/facebookincubator/create-react-app/blob/v0.2.3/template/README.md#adding-custom-environment-variables) and [`NODE_*`](https://github.com/facebookincubator/create-react-app/pull/476) environment variables are supported on Heroku during the compile phase, when `npm run build` is executed to generate the JavaScript bundle.
-
 Set [config vars on a Heroku app](https://devcenter.heroku.com/articles/config-vars) like this:
 
 ```bash
 heroku config:set REACT_APP_HELLO='I love sushi!'
 ```
 
-♻️ The app must be re-deployed for this change to take effect, because the automatic restart after a config var change does not rebuild the JavaScript bundle.
+#### Compile-time configuration
+
+For variables that will not change between environments, such as:
+
+  * version number
+  * commit sha or number
+  * browser support flags
+
+[`REACT_APP_*`](https://github.com/facebookincubator/create-react-app/blob/v0.2.3/template/README.md#adding-custom-environment-variables) and [`NODE_*`](https://github.com/facebookincubator/create-react-app/pull/476) environment variables are supported on Heroku during the compile phase, when `npm run build` is executed to generate the JavaScript bundle.
+
+♻️ The app must be re-deployed for compiled changed to take effect, because the automatic restart after a config var change does not rebuild the JavaScript bundle.
 
 ```bash
 git commit --allow-empty -m "Set REACT_APP_HELLO config var"
@@ -125,13 +133,11 @@ git push heroku master
 
 #### Runtime configuration
 
-🚨 Experimental using [heroku-buildpack-mustache](https://github.com/heroku/heroku-buildpack-mustache).
+For variables that may change between releases or environments:
 
-Create `mustache_templates.conf` with the following content:
-
-```
-build/index.html
-```
+  * Heroku add-on config vars
+  * URLs to APIs
+  * secret tokens
 
 Add script element to `index.html` to capture environment variable values:
 
@@ -141,7 +147,6 @@ Add script element to `index.html` to capture environment variable values:
     <script type="text/javascript">
       react_app_env = {};
       react_app_env.HELLO = '{{REACT_APP_HELLO}}';
-      react_app_env.GOODBYE = '{{REACT_APP_GOODBYE}}';
     </script>
   </head>
 ```
@@ -182,7 +187,9 @@ This buildpack composes three buildpacks (specified in [`.buildpacks`](.buildpac
 2. [`mars/create-react-app-inner-buildpack`](https://github.com/mars/create-react-app-inner-buildpack)
   * generates the [default `static.json`](#customization)
   * performs the production build for create-react-app, `npm run build`
-3. [`heroku/static` buildpack](https://github.com/heroku/heroku-buildpack-static)
+3. [`heroku/heroku-buildpack-mustache`](https://github.com/heroku/heroku-buildpack-mustache)
+  * performs [runtime replacement of environment variables](#runtime-configuration)
+4. [`heroku/static` buildpack](https://github.com/heroku/heroku-buildpack-static)
   * [Nginx](http://nginx.org/en/) web server
   * handy static website & SPA (single-page app) [customization options](https://github.com/heroku/heroku-buildpack-static#configuration)
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,40 @@ git commit --allow-empty -m "Set REACT_APP_HELLO config var"
 git push heroku master
 ```
 
+#### Runtime configuration
+
+🚨 Experimental using [heroku-buildpack-mustache](https://github.com/heroku/heroku-buildpack-mustache).
+
+Create `mustache_templates.conf` with the following content:
+
+```
+build/index.html
+```
+
+Add script element to `index.html` to capture environment variable values:
+
+```html
+  <head>
+    <!-- Existing head elements come first -->
+    <script type="text/javascript">
+      react_app_env = {};
+      react_app_env.HELLO = '{{REACT_APP_HELLO}}';
+      react_app_env.GOODBYE = '{{REACT_APP_GOODBYE}}';
+    </script>
+  </head>
+```
+
+Then, use these globals within the React app.
+
+```javascript
+const hello = react_app_env.HELLO;
+```
+
+Globals are normally considered dirty, so you may build up a more acceptable pattern for using these values in an app, such as:
+
+* create a module to read the global values and make them available via `require`
+* create a [higher order component [HOC]](https://medium.com/@dan_abramov/mixins-are-dead-long-live-higher-order-components-94a0d2f9e750) that makes the values available via props
+
 Version compatibility
 ---------------------
 

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ This buildpack composes three buildpacks (specified in [`.buildpacks`](.buildpac
   * complete Node.js enviroment to support the webpack build
   * `node_modules` cached between deployments
 2. [`mars/create-react-app-inner-buildpack`](https://github.com/mars/create-react-app-inner-buildpack)
+  * generates the default `mustache_templates.conf`
   * generates the [default `static.json`](#customization)
   * performs the production build for create-react-app, `npm run build`
 3. [`heroku/heroku-buildpack-mustache`](https://github.com/heroku/heroku-buildpack-mustache)

--- a/bin/compile
+++ b/bin/compile
@@ -35,15 +35,6 @@ rm -rf $dir
 # * Install `npm build` tooling.
 export NPM_CONFIG_PRODUCTION=false
 
-# Ensure this config exists so the buildpack successfully detects
-MUSTACHE_TEMPLATES_CONF="$BUILD_DIR/mustache_templates.conf"
-if [ -f "$MUSTACHE_TEMPLATES_CONF" ]; then
-  echo 'Using existing `mustache_templates.conf`' | indent
-else
-  echo 'Writing `mustache_templates.conf` to support create-react-app' | indent
-  echo "build/index.html" > "$MUSTACHE_TEMPLATES_CONF"
-fi
-
 echo "=====> Downloading Buildpack: $url"
 
 if [[ "$url" =~ \.tgz$ ]] || [[ "$url" =~ \.tgz\? ]]; then

--- a/bin/compile
+++ b/bin/compile
@@ -35,6 +35,15 @@ rm -rf $dir
 # * Install `npm build` tooling.
 export NPM_CONFIG_PRODUCTION=false
 
+# Ensure this config exists so the buildpack successfully detects
+MUSTACHE_TEMPLATES_CONF="$BUILD_DIR/mustache_templates.conf"
+if [ -f "$MUSTACHE_TEMPLATES_CONF" ]; then
+  echo 'Using existing `mustache_templates.conf`' | indent
+else
+  echo 'Writing `mustache_templates.conf` to support create-react-app' | indent
+  echo "build/index.html" > "$MUSTACHE_TEMPLATES_CONF"
+fi
+
 echo "=====> Downloading Buildpack: $url"
 
 if [[ "$url" =~ \.tgz$ ]] || [[ "$url" =~ \.tgz\? ]]; then


### PR DESCRIPTION
Proposed fix for #7.

See: [Runtime configuration docs](https://github.com/mars/create-react-app-buildpack/blob/runtime-env-vars/README.md#runtime-configuration) in the branch.

It's currently missing a good local developer experience; the variables are simply filled with the Mustache tags. It might be possible to populate the vars with a small local script wrapper for `npm start`.
