### PR TITLE
Modular runtime env vars

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,3 +1,4 @@
 https://github.com/heroku/heroku-buildpack-nodejs.git
-https://github.com/mars/create-react-app-inner-buildpack.git#v1.3.0
+https://github.com/mars/create-react-app-inner-buildpack.git#stateless-build
+https://github.com/heroku/heroku-buildpack-mustache.git
 https://github.com/heroku/heroku-buildpack-static.git

--- a/.buildpacks
+++ b/.buildpacks
@@ -1,3 +1,3 @@
 https://github.com/heroku/heroku-buildpack-nodejs.git
-https://github.com/mars/create-react-app-inner-buildpack.git#modular-runtime-env-vars
+https://github.com/mars/create-react-app-inner-buildpack.git#v2.0.0
 https://github.com/heroku/heroku-buildpack-static.git

--- a/.buildpacks
+++ b/.buildpacks
@@ -1,4 +1,4 @@
 https://github.com/heroku/heroku-buildpack-nodejs.git
-https://github.com/mars/create-react-app-inner-buildpack.git
+https://github.com/mars/create-react-app-inner-buildpack.git#runtime-env-vars
 https://github.com/heroku/heroku-buildpack-mustache.git
 https://github.com/heroku/heroku-buildpack-static.git

--- a/.buildpacks
+++ b/.buildpacks
@@ -1,4 +1,3 @@
 https://github.com/heroku/heroku-buildpack-nodejs.git
 https://github.com/mars/create-react-app-inner-buildpack.git#modular-runtime-env-vars
-https://github.com/heroku/heroku-buildpack-mustache.git
 https://github.com/heroku/heroku-buildpack-static.git

--- a/.buildpacks
+++ b/.buildpacks
@@ -1,4 +1,4 @@
 https://github.com/heroku/heroku-buildpack-nodejs.git
-https://github.com/mars/create-react-app-inner-buildpack.git#stateless-build
+https://github.com/mars/create-react-app-inner-buildpack.git
 https://github.com/heroku/heroku-buildpack-mustache.git
 https://github.com/heroku/heroku-buildpack-static.git

--- a/.buildpacks
+++ b/.buildpacks
@@ -1,4 +1,4 @@
 https://github.com/heroku/heroku-buildpack-nodejs.git
-https://github.com/mars/create-react-app-inner-buildpack.git#runtime-env-vars
+https://github.com/mars/create-react-app-inner-buildpack.git#modular-runtime-env-vars
 https://github.com/heroku/heroku-buildpack-mustache.git
 https://github.com/heroku/heroku-buildpack-static.git

--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ class App extends Component {
 }
 ```
 
+⚠️ *Avoid setting backslash escape sequences, such as `\n`, into Runtime config vars. Use literal UTF-8 values only; they will be automatically escaped.*
+
 #### Add-on config vars
 
 🤐 *Be careful not to export secrets. These values may be accessed by anyone who can see the React app.*

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ Create a `static.json` file to configure the web server for clean [`browserHisto
 
 ### Environment variables
 
+[`REACT_APP_*`](https://github.com/facebookincubator/create-react-app/blob/v0.2.3/template/README.md#adding-custom-environment-variables) are supported with this buildpack.
+
 Set [config vars on a Heroku app](https://devcenter.heroku.com/articles/config-vars) like this:
 
 ```bash
@@ -121,8 +123,6 @@ For variables that will not change between environments, such as:
   * version number
   * commit sha or number
   * browser support flags
-
-[`REACT_APP_*`](https://github.com/facebookincubator/create-react-app/blob/v0.2.3/template/README.md#adding-custom-environment-variables) and [`NODE_*`](https://github.com/facebookincubator/create-react-app/pull/476) environment variables are supported on Heroku during the compile phase, when `npm run build` is executed to generate the JavaScript bundle.
 
 ♻️ The app must be re-deployed for compiled changed to take effect, because the automatic restart after a config var change does not rebuild the JavaScript bundle.
 
@@ -139,9 +139,9 @@ For variables that may change between releases or environments:
   * URLs to APIs
   * secret tokens
 
-Any environment variable is accessible at runtime, not just `REACT_APP_*`.
+Runtime variables will be refreshed when setting new [config vars](https://devcenter.heroku.com/articles/config-vars), promoting through a [pipeline](https://devcenter.heroku.com/articles/pipelines), or [rolling back](https://devcenter.heroku.com/articles/releases#rollback) to a previous release.
 
-Install the runtime vars npm package, and then require/import it to use the vars anywhere in the app:
+Install the runtime vars npm package, and then require/import it to use the vars within components:
 
 ```bash
 npm install @mars/heroku-js-runtime-env --save

--- a/README.md
+++ b/README.md
@@ -141,28 +141,26 @@ For variables that may change between releases or environments:
 
 Any environment variable is accessible at runtime, not just `REACT_APP_*`.
 
-Add script element to `index.html` to capture environment variable values:
+Install the runtime vars npm package, and then require/import it to use the vars anywhere in the app:
 
-```html
-  <head>
-    <!-- Existing head elements come first -->
-    <script type="text/javascript">
-      react_app_env = {};
-      react_app_env.HELLO = '{{REACT_APP_HELLO}}';
-    </script>
-  </head>
+```bash
+npm install @mars/heroku-js-runtime-env --save
 ```
-
-Then, use these globals within the React app.
 
 ```javascript
-const hello = react_app_env.HELLO;
+import React, { Component } from 'react';
+import runtimeEnv from '@mars/heroku-js-runtime-env';
+
+const env = runtimeEnv();
+
+class App extends Component {
+  render() {
+    return (
+      <code>Runtime env var example: { env.REACT_APP_HELLO }</code>
+    );
+  }
+}
 ```
-
-Globals are normally considered dirty, so you may build up a more acceptable pattern for using these values in an app, such as:
-
-* create a module to read the global values and make them available via `require`
-* create a [higher order component [HOC]](https://medium.com/@dan_abramov/mixins-are-dead-long-live-higher-order-components-94a0d2f9e750) that makes the values available via props
 
 Version compatibility
 ---------------------

--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ Set [config vars on a Heroku app](https://devcenter.heroku.com/articles/config-v
 heroku config:set REACT_APP_HELLO='I love sushi!'
 ```
 
+You may implement variables at [compile-time](#compile-time-configuration) or [runtime](#runtime-configuration).
+
 #### Compile-time configuration
 
 For variables that will not change between environments, such as:
@@ -124,7 +126,7 @@ For variables that will not change between environments, such as:
   * commit sha or number
   * browser support flags
 
-♻️ The app must be re-deployed for compiled changed to take effect, because the automatic restart after a config var change does not rebuild the JavaScript bundle.
+♻️ The app must be re-deployed for compiled changed to take effect, because the automatic restart after a config var change does not rebuild the JavaScript bundle. If this is not desired behavior, then use [runtime configuration](#runtime-configuration) instead.
 
 ```bash
 git commit --allow-empty -m "Set REACT_APP_HELLO config var"
@@ -139,7 +141,7 @@ For variables that may change between releases or environments:
   * URLs to APIs
   * secret tokens
 
-Runtime variables will be refreshed when setting new [config vars](https://devcenter.heroku.com/articles/config-vars), promoting through a [pipeline](https://devcenter.heroku.com/articles/pipelines), or [rolling back](https://devcenter.heroku.com/articles/releases#rollback) to a previous release.
+Runtime variables will be refreshed for every release, when setting new [config vars](https://devcenter.heroku.com/articles/config-vars), promoting through a [pipeline](https://devcenter.heroku.com/articles/pipelines), or [rolling back](https://devcenter.heroku.com/articles/releases#rollback) to a previous release.
 
 Install the runtime vars npm package, and then require/import it to use the vars within components:
 
@@ -151,16 +153,22 @@ npm install @mars/heroku-js-runtime-env --save
 import React, { Component } from 'react';
 import runtimeEnv from '@mars/heroku-js-runtime-env';
 
-const env = runtimeEnv();
-
 class App extends Component {
   render() {
+    const env = runtimeEnv();
+
     return (
       <code>Runtime env var example: { env.REACT_APP_HELLO }</code>
     );
   }
 }
 ```
+
+These runtime values will be serialized as JSON, so their values must be compatible with JSON:
+
+* Quote `"` will be auto-escaped
+* Backslash `\` is a control character, so the standard [JSON string rules](http://json.org) apply
+* All other UTF-8 characters may be used freely.
 
 Version compatibility
 ---------------------

--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ Set [env vars on a Heroku app](https://devcenter.heroku.com/articles/config-vars
 heroku config:set REACT_APP_HELLO='I love sushi!'
 ```
 
+For local development, use [dotenv](https://www.npmjs.com/package/dotenv) to load variables from a `.env` file. *Requires at least create-react-app 0.7.*
+
 #### Compile-time vs Runtime
 
 Two versions of variables are supported. In addition to compile-time variables applied during [build](https://github.com/facebookincubator/create-react-app#npm-run-build), this buildpack supports runtime configuration as well.
@@ -145,6 +147,8 @@ git push heroku master
 ```
 
 #### Runtime configuration
+
+*Requires at least create-react-app 0.7.*
 
 Install the [runtime env npm package](https://www.npmjs.com/package/@mars/heroku-js-runtime-env):
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Usually, using master [as directed in the main instructions](#create-the-heroku-
 Architecture 🏙
 ------------
 
-This buildpack composes three buildpacks (specified in [`.buildpacks`](.buildpacks)) to support **no-configuration deployment** on Heroku:
+This buildpack composes several buildpacks (specified in [`.buildpacks`](.buildpacks)) to support **no-configuration deployment** on Heroku:
 
 1. [`heroku/nodejs` buildpack](https://github.com/heroku/heroku-buildpack-nodejs)
   * complete Node.js enviroment to support the webpack build

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Set [env vars on a Heroku app](https://devcenter.heroku.com/articles/config-vars
 heroku config:set REACT_APP_HELLO='I love sushi!'
 ```
 
-#### Compile-time vs runtime
+#### Compile-time vs Runtime
 
 Two versions of variables are supported. In addition to compile-time variables applied during [build](https://github.com/facebookincubator/create-react-app#npm-run-build), this buildpack supports runtime configuration as well.
 
@@ -171,11 +171,11 @@ class App extends Component {
 }
 ```
 
-These runtime values will be serialized as JSON, so their values must be compatible with JSON:
+👓 These runtime values will be serialized as JSON, so their values must be compatible with JSON:
 
-* Quote `"` will be auto-escaped
-* Backslash `\` is a control character, so the standard [JSON string rules](http://json.org) apply
-* All other UTF-8 characters may be used freely.
+* quote `"` will be auto-escaped
+* backslash `\` is a control character, so the standard [JSON string rules](http://json.org) apply
+* all other UTF-8 characters may be used freely.
 
 #### Add-on config vars
 
@@ -190,6 +190,7 @@ Use a custom [`.profile.d` script](https://devcenter.heroku.com/articles/buildpa
   ```bash
   export REACT_APP_ADDON_CONFIG=${ADDON_CONFIG:-}
   ```
+1. set-up & use [Runtime configuration](#runtime-configuration) to access the variables
 
 For example, to use the API key for the [Filestack](https://elements.heroku.com/addons/filepicker) JS image uploader:
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ For variables that may change between releases or environments:
   * URLs to APIs
   * secret tokens
 
+Any environment variable is accessible at runtime, not just `REACT_APP_*`.
+
 Add script element to `index.html` to capture environment variable values:
 
 ```html

--- a/README.md
+++ b/README.md
@@ -185,12 +185,10 @@ This buildpack composes several buildpacks (specified in [`.buildpacks`](.buildp
   * complete Node.js enviroment to support the webpack build
   * `node_modules` cached between deployments
 2. [`mars/create-react-app-inner-buildpack`](https://github.com/mars/create-react-app-inner-buildpack)
-  * generates the default `mustache_templates.conf`
+  * enables [runtime environment variables](#runtime-configuration)
   * generates the [default `static.json`](#customization)
   * performs the production build for create-react-app, `npm run build`
-3. [`heroku/heroku-buildpack-mustache`](https://github.com/heroku/heroku-buildpack-mustache)
-  * performs [runtime replacement of environment variables](#runtime-configuration)
-4. [`heroku/static` buildpack](https://github.com/heroku/heroku-buildpack-static)
+3. [`heroku/static` buildpack](https://github.com/heroku/heroku-buildpack-static)
   * [Nginx](http://nginx.org/en/) web server
   * handy static website & SPA (single-page app) [customization options](https://github.com/heroku/heroku-buildpack-static#configuration)
 

--- a/README.md
+++ b/README.md
@@ -108,15 +108,23 @@ Create a `static.json` file to configure the web server for clean [`browserHisto
 
 ### Environment variables
 
-[`REACT_APP_*`](https://github.com/facebookincubator/create-react-app/blob/v0.2.3/template/README.md#adding-custom-environment-variables) and [`NODE_*`](https://github.com/facebookincubator/create-react-app/pull/476) environment variables are supported on Heroku during the compile phase, when `npm run build` is executed to generate the JavaScript bundle.
-
 Set [config vars on a Heroku app](https://devcenter.heroku.com/articles/config-vars) like this:
 
 ```bash
 heroku config:set REACT_APP_HELLO='I love sushi!'
 ```
 
-♻️ The app must be re-deployed for this change to take effect, because the automatic restart after a config var change does not rebuild the JavaScript bundle.
+#### Compile-time configuration
+
+For variables that will not change between environments, such as:
+
+  * version number
+  * commit sha or number
+  * browser support flags
+
+[`REACT_APP_*`](https://github.com/facebookincubator/create-react-app/blob/v0.2.3/template/README.md#adding-custom-environment-variables) and [`NODE_*`](https://github.com/facebookincubator/create-react-app/pull/476) environment variables are supported on Heroku during the compile phase, when `npm run build` is executed to generate the JavaScript bundle.
+
+♻️ The app must be re-deployed for compiled changed to take effect, because the automatic restart after a config var change does not rebuild the JavaScript bundle.
 
 ```bash
 git commit --allow-empty -m "Set REACT_APP_HELLO config var"
@@ -125,13 +133,11 @@ git push heroku master
 
 #### Runtime configuration
 
-🚨 Experimental using [heroku-buildpack-mustache](https://github.com/heroku/heroku-buildpack-mustache).
+For variables that may change between releases or environments:
 
-Create `mustache_templates.conf` with the following content:
-
-```
-build/index.html
-```
+  * Heroku add-on config vars
+  * URLs to APIs
+  * secret tokens
 
 Add script element to `index.html` to capture environment variable values:
 
@@ -141,7 +147,6 @@ Add script element to `index.html` to capture environment variable values:
     <script type="text/javascript">
       react_app_env = {};
       react_app_env.HELLO = '{{REACT_APP_HELLO}}';
-      react_app_env.GOODBYE = '{{REACT_APP_GOODBYE}}';
     </script>
   </head>
 ```
@@ -182,7 +187,9 @@ This buildpack composes three buildpacks (specified in [`.buildpacks`](.buildpac
 2. [`mars/create-react-app-inner-buildpack`](https://github.com/mars/create-react-app-inner-buildpack)
   * generates the [default `static.json`](#customization)
   * performs the production build for create-react-app, `npm run build`
-3. [`heroku/static` buildpack](https://github.com/heroku/heroku-buildpack-static)
+3. [`heroku/heroku-buildpack-mustache`](https://github.com/heroku/heroku-buildpack-mustache)
+  * performs [runtime replacement of environment variables](#runtime-configuration)
+4. [`heroku/static` buildpack](https://github.com/heroku/heroku-buildpack-static)
   * [Nginx](http://nginx.org/en/) web server
   * handy static website & SPA (single-page app) [customization options](https://github.com/heroku/heroku-buildpack-static#configuration)
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,40 @@ git commit --allow-empty -m "Set REACT_APP_HELLO config var"
 git push heroku master
 ```
 
+#### Runtime configuration
+
+🚨 Experimental using [heroku-buildpack-mustache](https://github.com/heroku/heroku-buildpack-mustache).
+
+Create `mustache_templates.conf` with the following content:
+
+```
+build/index.html
+```
+
+Add script element to `index.html` to capture environment variable values:
+
+```html
+  <head>
+    <!-- Existing head elements come first -->
+    <script type="text/javascript">
+      react_app_env = {};
+      react_app_env.HELLO = '{{REACT_APP_HELLO}}';
+      react_app_env.GOODBYE = '{{REACT_APP_GOODBYE}}';
+    </script>
+  </head>
+```
+
+Then, use these globals within the React app.
+
+```javascript
+const hello = react_app_env.HELLO;
+```
+
+Globals are normally considered dirty, so you may build up a more acceptable pattern for using these values in an app, such as:
+
+* create a module to read the global values and make them available via `require`
+* create a [higher order component [HOC]](https://medium.com/@dan_abramov/mixins-are-dead-long-live-higher-order-components-94a0d2f9e750) that makes the values available via props
+
 Version compatibility
 ---------------------
 

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ This buildpack composes three buildpacks (specified in [`.buildpacks`](.buildpac
   * complete Node.js enviroment to support the webpack build
   * `node_modules` cached between deployments
 2. [`mars/create-react-app-inner-buildpack`](https://github.com/mars/create-react-app-inner-buildpack)
+  * generates the default `mustache_templates.conf`
   * generates the [default `static.json`](#customization)
   * performs the production build for create-react-app, `npm run build`
 3. [`heroku/heroku-buildpack-mustache`](https://github.com/heroku/heroku-buildpack-mustache)

--- a/README.md
+++ b/README.md
@@ -175,12 +175,6 @@ class App extends Component {
 }
 ```
 
-👓 These runtime values will be serialized as JSON, so their values must be compatible with JSON:
-
-* quote `"` will be auto-escaped
-* backslash `\` is a control character, so the standard [JSON string rules](http://json.org) apply
-* all other UTF-8 characters may be used freely.
-
 #### Add-on config vars
 
 🤐 *Be careful not to export secrets. These values may be accessed by anyone who can see the React app.*

--- a/bin/compile
+++ b/bin/compile
@@ -35,15 +35,6 @@ rm -rf $dir
 # * Install `npm build` tooling.
 export NPM_CONFIG_PRODUCTION=false
 
-# Ensure this config exists so the buildpack successfully detects
-MUSTACHE_TEMPLATES_CONF="$BUILD_DIR/mustache_templates.conf"
-if [ -f "$MUSTACHE_TEMPLATES_CONF" ]; then
-  echo 'Using existing `mustache_templates.conf`' | indent
-else
-  echo 'Writing `mustache_templates.conf` to support create-react-app' | indent
-  echo "build/index.html" > "$MUSTACHE_TEMPLATES_CONF"
-fi
-
 echo "=====> Downloading Buildpack: $url"
 
 if [[ "$url" =~ \.tgz$ ]] || [[ "$url" =~ \.tgz\? ]]; then

--- a/bin/compile
+++ b/bin/compile
@@ -35,6 +35,15 @@ rm -rf $dir
 # * Install `npm build` tooling.
 export NPM_CONFIG_PRODUCTION=false
 
+# Ensure this config exists so the buildpack successfully detects
+MUSTACHE_TEMPLATES_CONF="$BUILD_DIR/mustache_templates.conf"
+if [ -f "$MUSTACHE_TEMPLATES_CONF" ]; then
+  echo 'Using existing `mustache_templates.conf`' | indent
+else
+  echo 'Writing `mustache_templates.conf` to support create-react-app' | indent
+  echo "build/index.html" > "$MUSTACHE_TEMPLATES_CONF"
+fi
+
 echo "=====> Downloading Buildpack: $url"
 
 if [[ "$url" =~ \.tgz$ ]] || [[ "$url" =~ \.tgz\? ]]; then


### PR DESCRIPTION
🚧 Requires the unreleased react-scripts 0.7 for [access to `process.env` as an object](https://github.com/facebookincubator/create-react-app/pull/807) in local development.

Solution for [issue #7 "Env vars are compiled into app"](https://github.com/mars/create-react-app-buildpack/issues/7).

The main code change is in the [inner buildpack](https://github.com/mars/create-react-app-inner-buildpack/pull/3/files).
