### PR TITLE
Add yarn install step to generate lock file

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ create-react-app $APP_NAME
 cd $APP_NAME
 git init
 heroku create $APP_NAME --buildpack https://github.com/mars/create-react-app-buildpack.git
+yarn install
 git add .
 git commit -m "Start with create-react-app"
 git push heroku master


### PR DESCRIPTION
When pushing the first time to heroku the build fails if no matching yarn lock file is found.