### PR TITLE
Allow ENV_DIR to be empty string if it is not given

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -20,7 +20,7 @@ function indent() {
 
 BUILD_DIR=$1
 CACHE_DIR=$2
-ENV_DIR=$3
+ENV_DIR=${3:-}
 BP_DIR=`cd $(dirname $0); cd ..; pwd`
 
 # Use architecture of multi-buildpack to compose behavior.


### PR DESCRIPTION
I'm using deis v1 and deis v2. deis v2 is okay but deis v1 doesn't pass `ENV_DIR`. https://github.com/deis/slugbuilder/pull/85
Can we allow `ENV_DIR` to be empty string if it is not given?

I was getting this error: 

```
...
remote: [1G[1G-----> Fetching custom buildpack[K
remote: [1G[1G-----> React.js (create-react-app) multi app detected[K
remote: [1G/tmp/buildpacks/custom/bin/compile: line 23: $3: unbound variable[K
```

refs: 
* https://github.com/deis/deis/issues/1738
* https://github.com/heroku/heroku-buildpack-nodejs/blob/master/bin/compile#L19