### PR TITLE
Deploy with auto build

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,3 +1,3 @@
 https://github.com/heroku/heroku-buildpack-nodejs.git
-https://github.com/mars/create-react-app-inner-buildpack.git#v8.0.0
+https://github.com/mars/create-react-app-inner-buildpack.git#deploy-with-auto-build
 https://github.com/heroku/heroku-buildpack-static.git

--- a/.buildpacks
+++ b/.buildpacks
@@ -1,3 +1,3 @@
 https://github.com/heroku/heroku-buildpack-nodejs.git
-https://github.com/mars/create-react-app-inner-buildpack.git#deploy-with-auto-build
+https://github.com/mars/create-react-app-inner-buildpack.git#v9.0.0
 https://github.com/heroku/heroku-buildpack-static.git

--- a/README.md
+++ b/README.md
@@ -532,10 +532,7 @@ This buildpack combines several buildpacks, specified in [`.buildpacks`](.buildp
      * [executes the npm package's build script](https://devcenter.heroku.com/changelog-items/1557); create-react-app default is `react-scripts build`
      * exposes all env vars to the build script
      * generates a production bundle regardless of `NODE_ENV` setting
-   * `NODE_ENV` at buildtime:
-     * defaults to `NODE_ENV=development` to install the build tooling of create-react-app's dev dependencies, like `react-scripts`
-     * honors specific setting of `NODE_ENV`, like `NODE_ENV=test` for [automated testing](#user-content-testing) in [`bin/test`](bin/test-compile)
-     * but forces `NODE_ENV=production` to be `development` to ensure dev dependencies are available for build
+     * customize further with [Node.js build configuration](https://devcenter.heroku.com/articles/nodejs-support#customizing-the-build-process)
 2. [`mars/create-react-app-inner-buildpack`](https://github.com/mars/create-react-app-inner-buildpack)
    * sets default [web server config](#user-content-web-server) unless `static.json` already exists
    * enables [runtime environment variables](#user-content-environment-variables)

--- a/README.md
+++ b/README.md
@@ -356,7 +356,9 @@ ex: `REACT_APP_FILEPICKER_API_KEY` ([Add-on config vars](#user-content-add-on-co
 
 ### Compile-time configuration
 
-Supports [`REACT_APP_`](https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#adding-custom-environment-variables), `NODE_`, `NPM_`, & `HEROKU_` prefixed variables.
+Supports all config vars, including [`REACT_APP_`](https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#adding-custom-environment-variables), `NODE_`, `NPM_`, & `HEROKU_` prefixed variables.
+
+☝️🤐 ***Use secrets carefully.** If these values are embedded in the JavaScript bundle, like with `REACT_APP_` vars, then they may be accessed by anyone who can see the React app.*
 
 Use Node's [`process.env` object](https://nodejs.org/dist/latest-v10.x/docs/api/process.html#process_process_env).
 
@@ -526,15 +528,15 @@ This buildpack combines several buildpacks, specified in [`.buildpacks`](.buildp
    * installs `node`, puts on the `$PATH`
    * version specified in [`package.json`, `engines.node`](https://devcenter.heroku.com/articles/nodejs-support#specifying-a-node-js-version)
    * `node_modules/` cached between deployments
+   * production build for create-react-app
+     * [executes the npm package's build script](https://devcenter.heroku.com/changelog-items/1557); create-react-app default is `react-scripts build`
+     * exposes all env vars to the build script
+     * generates a production bundle regardless of `NODE_ENV` setting
    * `NODE_ENV` at buildtime:
      * defaults to `NODE_ENV=development` to install the build tooling of create-react-app's dev dependencies, like `react-scripts`
      * honors specific setting of `NODE_ENV`, like `NODE_ENV=test` for [automated testing](#user-content-testing) in [`bin/test`](bin/test-compile)
      * but forces `NODE_ENV=production` to be `development` to ensure dev dependencies are available for build
 2. [`mars/create-react-app-inner-buildpack`](https://github.com/mars/create-react-app-inner-buildpack)
-   * production build for create-react-app
-     * executes the npm package's build script; create-react-app default is `react-scripts build`
-     * exposes `REACT_APP_`, `NODE_`, `NPM_`, & `HEROKU_` prefixed env vars to the build script
-     * generates a production bundle regardless of `NODE_ENV` setting
    * sets default [web server config](#user-content-web-server) unless `static.json` already exists
    * enables [runtime environment variables](#user-content-environment-variables)
 3. [`heroku/static` buildpack](https://github.com/heroku/heroku-buildpack-static)

--- a/bin/compile
+++ b/bin/compile
@@ -23,6 +23,9 @@ CACHE_DIR=$2
 ENV_DIR=$3
 BP_DIR=`cd $(dirname $0); cd ..; pwd`
 
+# Switch to new Node auto build behavior ahead of release
+export NEW_BUILD_SCRIPT_BEHAVIOR=true
+
 # Use architecture of multi-buildpack to compose behavior.
 # https://github.com/heroku/heroku-buildpack-multi
 cp $BP_DIR/.buildpacks $BUILD_DIR/.buildpacks

--- a/bin/compile
+++ b/bin/compile
@@ -31,21 +31,6 @@ branch=""
 dir=$(mktemp -t buildpackXXXXX)
 rm -rf $dir
 
-echo "-----> Configure create-react-app build environment"
-# Set env vars for the inner buildpacks in `.buildpacks`
-# * during compile, install build tooling (devDependencies) with npm & Yarn
-# * in runtime, NODE_ENV is not used (this buildpack launches a static web server)
-export NPM_CONFIG_PRODUCTION=false
-INHERITED_NODE_ENV="${NODE_ENV:-development}"
-if [ "$INHERITED_NODE_ENV" = "production" ]
-  then
-  echo '       Setting `NODE_ENV=development` to install dependencies for `npm build`'
-  export NODE_ENV=development
-else
-  echo "       Using \`NODE_ENV=${INHERITED_NODE_ENV}\`"
-  export NODE_ENV="${INHERITED_NODE_ENV}"
-fi
-
 echo "=====> Downloading Buildpack: $url"
 
 if [[ "$url" =~ \.tgz$ ]] || [[ "$url" =~ \.tgz\? ]]; then


### PR DESCRIPTION
Resolves #155 

Adapts this buildpack for the [upcoming change](https://devcenter.heroku.com/changelog-items/1557) to the official Node.js buildpack.

⛵️ **No changes are required to apps deployed with the master version of this buildpack.** The `npx @heroku/update-node-build-script` changes should NOT be applied to apps deployed with master version of this buildpack.

Includes a few inherent changes to [the architecture](https://github.com/mars/create-react-app-buildpack/tree/deploy-with-auto-build#user-content-architecture-):

* the Node buildpack **executes `npm run build` automatically**
* the Node buildpack **installs `devDependencies` for auto build** (and afterwards it prunes them), so a confusing `NODE_ENV` workaround has been removed
* the Node buildpack makes **all config vars available during auto build**, so [compile-time configuration](https://github.com/mars/create-react-app-buildpack/tree/deploy-with-auto-build#user-content-compile-time-configuration) has access to all config vars.

### Release Schedule

This feature will be merged & released on **March 11, 2019**, before the Node buildpack switches over, so that the transition to auto build is seamless.

### Get Ready

If you want to test this, follow these instructions to switch to the new behavior ahead of its release. Otherwise, you do not need to do anything to continue using this buildpack before, on, or after March 11.

Set your app to use this buildpack branch:

```
heroku buildpacks:set https://github.com/mars/create-react-app-buildpack#deploy-with-auto-build
```

⚠️ If you already set `"heroku-postbuild": "echo Skip build on Heroku"` to avoid the new auto build behavior, then make sure to *remove that property* from `package.json` so that auto build can run.

Finally, remember to switch the app back to the master buildpack release so that your app automatically receive buildpack updates:

```
heroku buildpacks:set mars/create-react-app
```

### Test It & Holler

Use the *Get Ready* instructions above to try it ahead of time and let me know if you find any problems!

Especially thank you @jmorrell for continuing to evolve the Node.js buildpack 🥓💯✅💜  and messaging so clearly about this upcoming change!
