### PR TITLE
specified a static heroku-buildpack-nodejs version. fixes issue #181

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,3 +1,3 @@
-https://github.com/heroku/heroku-buildpack-nodejs.git
+https://github.com/heroku/heroku-buildpack-nodejs.git#v176
 https://github.com/mars/create-react-app-inner-buildpack.git#v9.0.0
 https://github.com/heroku/heroku-buildpack-static.git


### PR DESCRIPTION
Since the latest version of heroku-buildpack-nodejs is not the master branch, they recommend referencing specific versions by using tags, since master could (and is) unstable.

At the moment, heroku-buildpack-nodejs [doesn't have a "latest" tag of sorts](https://github.com/heroku/heroku-buildpack-nodejs/issues/856#issuecomment-722677083), so we have to put the latest version tag manually.

It fixes issue #181 related to dokku deployments failing due to that buildpack. 
